### PR TITLE
Jackson2 ObjectMapper Builder 재정의

### DIFF
--- a/pic-api/src/main/kotlin/com/mashup/pic/config/JacksonConfig.kt
+++ b/pic-api/src/main/kotlin/com/mashup/pic/config/JacksonConfig.kt
@@ -1,0 +1,31 @@
+package com.mashup.pic.config
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Configuration
+class JacksonConfig {
+
+    @Bean
+    fun jackson2ObjectMapperBuilder(customizers: List<Jackson2ObjectMapperBuilderCustomizer>): Jackson2ObjectMapperBuilder {
+        val builder = Jackson2ObjectMapperBuilder()
+            .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .serializerByType(LocalDateTime::class.java, LocalDateTimeSerializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .serializerByType(LocalDate::class.java, LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE))
+            .serializerByType(LocalTime::class.java, LocalTimeSerializer(DateTimeFormatter.ISO_LOCAL_TIME))
+        customizers.forEach { customizer -> customizer.customize(builder) }
+        return builder
+    }
+}


### PR DESCRIPTION
# 진행한 일
- Jack2ObjectMapperBuilder 재정의

---
DATE와 관련된 필드를 Json 포맷으로 변경할 때 Timestamp가 아닌 정형화된 포맷으로 변경하였습니다.

추후에 Deserializer나 Serializer를 추가해야 하는 경우 스프링 권장 사항인 Module 빈 추가로 진행하면 될 것 같습니다.